### PR TITLE
fixed top nav anchor not being centered on all browsers

### DIFF
--- a/resource/css/main.css
+++ b/resource/css/main.css
@@ -95,11 +95,12 @@ header .logo {
 /* Styling the navigation menu */
 nav {
 	/* subtract logo size so About can be in the middle */
-	/* faking absolute positoning so background still scales with content */
-	margin-left: -2.8em;
+	/* padding right to match logo */
+	margin: auto 2.8em auto 0;
 	/* grow the bar to fill in the space */
 	flex: 1;
-	align-content: center;
+	/* align-content without grid or border does not work on all browsers */
+	/* align-content: center; */
 	/* redundent due to flex: 1 */
 	/* width: 70%; */
 }


### PR DESCRIPTION
Fix for:
https://trello.com/c/eY2ASFXi
Changed to margin auto top and bottom, instead of align-content: center.

Also changed margin left -2.8em to adding 2.8em to right margin so it doesn't break too badly when window is smaller.